### PR TITLE
feat(fields): add dates support to minus.js and number.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clean": "rimraf lib dist es coverage",
     "lint": "eslint src test",
     "check": "npm run lint && npm run test",
-    "test": "cross-env BABEL_ENV=commonjs jest",
+    "test": "cross-env BABEL_ENV=commonjs jest --detectOpenHandles",
     "coverage": "cross-env BABEL_ENV=commonjs jest --coverage",
     "build": "npm run build:commonjs && npm run build:es && npm run build:umd && npm run build:umd:min",
     "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir lib",

--- a/src/clickup.config.js
+++ b/src/clickup.config.js
@@ -1,0 +1,5 @@
+const ClickUpConfiguration = {
+  UseNumericOverrides: false,
+};
+
+export default ClickUpConfiguration;

--- a/src/clickup.config.js
+++ b/src/clickup.config.js
@@ -1,5 +1,6 @@
 const ClickUpConfiguration = {
-  UseNumericOverrides: false,
+  ConvertDatesToNumbers: false,
+  ConvertFormulasInNumbers: false,
 };
 
 export default ClickUpConfiguration;

--- a/src/evaluate-by-operator/operator/minus.js
+++ b/src/evaluate-by-operator/operator/minus.js
@@ -1,10 +1,16 @@
 import {toNumber} from './../../helper/number';
 import {ERROR_VALUE} from './../../error';
+import ClickUpConfiguration from '../../clickup.config';
 
 export const SYMBOL = '-';
 
 export default function func(first, ...rest) {
-  const result = rest.reduce((acc, value) => acc - toNumber(value), toNumber(first));
+  const toNumberConfig = {
+    convertDatesToNumbers: ClickUpConfiguration.ConvertDatesToNumbers,
+    convertFormulasInNumbers: ClickUpConfiguration.ConvertFormulasInNumbers,
+  };
+
+  const result = rest.reduce((acc, value) => acc - toNumber(value, toNumberConfig), toNumber(first, toNumberConfig));
 
   if (isNaN(result)) {
     throw Error(ERROR_VALUE);

--- a/src/helper/date.js
+++ b/src/helper/date.js
@@ -6,6 +6,7 @@ export function dateToNumber(val) {
   if (isDate(val)) {
     return val.getTime();
   }
+
   return val;
 }
 
@@ -14,8 +15,10 @@ function isNullOrFalse(arg) {
 }
 
 export function canCompareArgs(arg1, arg2) {
-  if (isDate(arg1) && isNullOrFalse(arg2) || isDate(arg2) && isNullOrFalse(arg1)) {
-    return false;
-  }
-  return true;
+  return !(isDate(arg1) && isNullOrFalse(arg2) || isDate(arg2) && isNullOrFalse(arg1));
+}
+
+export function getNumberOfDaysSinceEpoch(date) {
+  const millisecondsInADay = 8.64e7;
+  return Math.floor(dateToNumber(date) / millisecondsInADay);
 }

--- a/src/helper/date.js
+++ b/src/helper/date.js
@@ -1,3 +1,5 @@
+const MillisecondsInADay = 24 * 60 * 60 * 1000;
+
 export function isDate(val) {
   return val instanceof Date;
 }
@@ -19,6 +21,5 @@ export function canCompareArgs(arg1, arg2) {
 }
 
 export function getNumberOfDaysSinceEpoch(date) {
-  const millisecondsInADay = 8.64e7;
-  return Math.floor(dateToNumber(date) / millisecondsInADay);
+  return Math.floor(dateToNumber(date) / MillisecondsInADay);
 }

--- a/src/helper/formula.js
+++ b/src/helper/formula.js
@@ -16,7 +16,7 @@ function filterEmptyArguments(el) {
  *
  * @examples
  * splitFormula(DATE(2024, 1, 1)) -> {name: 'DATE', args: [2024, 1, 1]}
- * splitFormula(MEDIAN([0,1,2])) -> {name: 'MEDIAN', args: [[0, 1, 2]]}
+ * splitFormula(TODAY()) -> {name: 'TODAY', args: []}
  */
 export default function splitFormula(formula) {
   const [name, argsString] = formula.split('(');

--- a/src/helper/formula.js
+++ b/src/helper/formula.js
@@ -1,0 +1,30 @@
+function parseArgument(el) {
+  return JSON.parse(el);
+}
+
+function filterEmptyArguments(el) {
+  return el !== '';
+}
+
+/**
+ * @description
+ * ! As for now it does not support arrays.
+ * ex: MEDIAN([0,1,2])
+ *
+ * @param formula - Provide a formula to split.
+ * @returns {{args: *, name: String}}
+ *
+ * @examples
+ * splitFormula(DATE(2024, 1, 1)) -> {name: 'DATE', args: [2024, 1, 1]}
+ * splitFormula(MEDIAN([0,1,2])) -> {name: 'MEDIAN', args: [[0, 1, 2]]}
+ */
+export default function splitFormula(formula) {
+  const [name, argsString] = formula.split('(');
+  const args = argsString.split(')')[0].split(',').filter(filterEmptyArguments);
+
+  return {
+    name,
+    args: args.map(parseArgument),
+  };
+}
+

--- a/src/helper/number.js
+++ b/src/helper/number.js
@@ -1,20 +1,36 @@
+import * as formulajs from '@formulajs/formulajs';
+import splitFormula from './formula';
+import {getNumberOfDaysSinceEpoch, isDate} from './date';
+import {ClickUpConfiguration} from '../parser';
+
+const AcceptedFormulaJSConversions = ['DATE('];
+
 /**
  * Convert value into number.
  *
- * @param {String|Number} number
+ * @param {String|Number} value
  * @returns {*}
  */
-export function toNumber(number) {
-  let result;
-
-  if (typeof number === 'number') {
-    result = number;
-
-  } else if (typeof number === 'string') {
-    result = number.indexOf('.') > -1 ? parseFloat(number) : parseInt(number, 10);
+export function toNumber(value) {
+  if (typeof value === 'number') {
+    return value;
   }
 
-  return result;
+  if (typeof value === 'string') {
+    const shouldBeParsed = AcceptedFormulaJSConversions.some((conversion) => value.startsWith(conversion));
+    if (shouldBeParsed && ClickUpConfiguration.UseNumericOverrides) {
+      const {name, args} = splitFormula(value);
+      return toNumber(formulajs[name](...args));
+    }
+
+    return value.indexOf('.') > -1 ? parseFloat(value) : parseInt(value, 10);
+  }
+
+  if (isDate(value) && ClickUpConfiguration.UseNumericOverrides) {
+    return getNumberOfDaysSinceEpoch(value);
+  }
+
+  return NaN;
 }
 
 /**

--- a/src/helper/number.js
+++ b/src/helper/number.js
@@ -1,7 +1,8 @@
 import * as formulajs from '@formulajs/formulajs';
 import splitFormula from './formula';
 import {getNumberOfDaysSinceEpoch, isDate} from './date';
-import {ClickUpConfiguration} from '../parser';
+
+import ClickUpConfiguration from '../clickup.config';
 
 const AcceptedFormulaJSConversions = ['DATE('];
 

--- a/src/helper/number.js
+++ b/src/helper/number.js
@@ -2,36 +2,38 @@ import * as formulajs from '@formulajs/formulajs';
 import splitFormula from './formula';
 import {getNumberOfDaysSinceEpoch, isDate} from './date';
 
-import ClickUpConfiguration from '../clickup.config';
-
 const AcceptedFormulaJSConversions = ['DATE('];
 
 /**
  * Convert value into number.
  *
  * @param {String|Number} value
+ * @param {Object} config
  * @returns {*}
  */
-export function toNumber(value) {
+export function toNumber(value, config = {
+  convertDatesToNumbers: false,
+  convertFormulasInNumbers: false,
+}) {
   if (typeof value === 'number') {
     return value;
   }
 
   if (typeof value === 'string') {
     const shouldBeParsed = AcceptedFormulaJSConversions.some((conversion) => value.startsWith(conversion));
-    if (shouldBeParsed && ClickUpConfiguration.UseNumericOverrides) {
+    if (shouldBeParsed && Boolean(config.convertFormulasInNumbers)) {
       const {name, args} = splitFormula(value);
-      return toNumber(formulajs[name](...args));
+      return toNumber(formulajs[name](...args), config);
     }
 
     return value.indexOf('.') > -1 ? parseFloat(value) : parseInt(value, 10);
   }
 
-  if (isDate(value) && ClickUpConfiguration.UseNumericOverrides) {
+  if (isDate(value) && Boolean(config.convertDatesToNumbers)) {
     return getNumberOfDaysSinceEpoch(value);
   }
 
-  return NaN;
+  return undefined;
 }
 
 /**

--- a/src/parser.js
+++ b/src/parser.js
@@ -3,9 +3,13 @@ import JSON5 from 'json5';
 import evaluateByOperator from './evaluate-by-operator/evaluate-by-operator';
 import {Parser as GrammarParser} from './grammar-parser/grammar-parser';
 import {trimEdges} from './helper/string';
-import {toNumber, invertNumber} from './helper/number';
-import errorParser, {isValidStrict as isErrorValid, ERROR, ERROR_NAME} from './error';
+import {invertNumber, toNumber} from './helper/number';
+import errorParser, {ERROR, ERROR_NAME, isValidStrict as isErrorValid} from './error';
 import {extractLabel, toLabel} from './helper/cell';
+
+export const ClickUpConfiguration = {
+  UseNumericOverrides: false,
+};
 
 /**
  * @class Parser
@@ -44,6 +48,10 @@ class Parser extends Emitter {
   parse(expression) {
     let result = null;
     let error = null;
+
+    Object.assign({
+      UseNumericOverrides: this.getVariable('USE_NUMERIC_OVERRIDES'),
+    });
 
     try {
       if (expression === '') {

--- a/src/parser.js
+++ b/src/parser.js
@@ -6,10 +6,7 @@ import {trimEdges} from './helper/string';
 import {invertNumber, toNumber} from './helper/number';
 import errorParser, {ERROR, ERROR_NAME, isValidStrict as isErrorValid} from './error';
 import {extractLabel, toLabel} from './helper/cell';
-
-export const ClickUpConfiguration = {
-  UseNumericOverrides: false,
-};
+import ClickUpConfiguration from './clickup.config';
 
 /**
  * @class Parser
@@ -49,7 +46,7 @@ class Parser extends Emitter {
     let result = null;
     let error = null;
 
-    Object.assign({
+    Object.assign(ClickUpConfiguration, {
       UseNumericOverrides: this.getVariable('USE_NUMERIC_OVERRIDES'),
     });
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -47,7 +47,8 @@ class Parser extends Emitter {
     let error = null;
 
     Object.assign(ClickUpConfiguration, {
-      UseNumericOverrides: this.getVariable('USE_NUMERIC_OVERRIDES'),
+      ConvertFormulasInNumbers: this.getVariable('CONVERT_FORMULAS_IN_NUMBERS'),
+      ConvertDatesToNumbers: this.getVariable('CONVERT_DATES_TO_NUMBERS'),
     });
 
     try {

--- a/test/integration/parsing/formula.js
+++ b/test/integration/parsing/formula.js
@@ -52,12 +52,16 @@ describe('.parse()', () => {
       ],
     ];
 
-    it.each(dateTestCases)('if the flag "USE_NUMERIC_OVERRIDES" is off, it should not calculate date subtraction', (formula, expectedResult) => {
-      expect(parser.parse(formula)).toMatchObject({ error: '#VALUE!', result: null});
-    });
+    // eslint-disable-next-line max-len
+    it.each(dateTestCases)(
+      'if flags "CONVERT_FORMULAS_IN_NUMBERS" and "CONVERT_DATES_TO_NUMBERS" are off, it should not calculate date subtraction',
+      (formula) => {
+        expect(parser.parse(formula)).toMatchObject({ error: '#VALUE!', result: null});
+      });
 
     it.each(dateTestCases)('should calculate date subtraction', (formula, expectedResult) => {
-      parser.setVariable('USE_NUMERIC_OVERRIDES', true);
+      parser.setVariable('', true).setVariable('CONVERT_DATES_TO_NUMBERS', true);
+
       expect(parser.parse(formula)).toMatchObject({ error: null, result: expectedResult});
     });
   });

--- a/test/integration/parsing/formula.js
+++ b/test/integration/parsing/formula.js
@@ -6,6 +6,7 @@ describe('.parse()', () => {
   beforeEach(() => {
     parser = new Parser();
   });
+
   afterEach(() => {
     parser = null;
   });
@@ -25,5 +26,35 @@ describe('.parse()', () => {
     parser.setVariable('foo', [7, 3.5, 3.5, 1, 2]);
 
     expect(parser.parse('sum(2, 3, Rank.eq(2, foo))')).toMatchObject({error: null, result: 9});
+  });
+
+  describe.only('ClickUp Overrides', () => {
+    const dateTestCases = [
+      [
+        'SUM(DATE(2021,1,1) - 2)',
+        18625,
+      ],
+      [
+        'SUM(DATE(2021,1,1) - DATE(2021,1,2))',
+        -1,
+      ],
+      [
+        'SUM(DATE(2022,1,1) - DATE(2021,1,1))',
+        365,
+      ],
+      [
+        'CONCATENATE(DATE(2022,1,1) - DATE(2021,1,1))',
+        '365',
+      ],
+    ];
+
+    it.each(dateTestCases)('if the flag "USE_NUMERIC_OVERRIDES" is off, it should not calculate date subtraction', (formula, expectedResult) => {
+      expect(parser.parse(formula)).toMatchObject({ error: '#VALUE!', result: null});
+    });
+
+    it.each(dateTestCases)('should calculate date subtraction', (formula, expectedResult) => {
+      parser.setVariable('USE_NUMERIC_OVERRIDES', true);
+      expect(parser.parse(formula)).toMatchObject({ error: null, result: expectedResult});
+    });
   });
 });

--- a/test/integration/parsing/formula.js
+++ b/test/integration/parsing/formula.js
@@ -28,7 +28,7 @@ describe('.parse()', () => {
     expect(parser.parse('sum(2, 3, Rank.eq(2, foo))')).toMatchObject({error: null, result: 9});
   });
 
-  describe.only('ClickUp Overrides', () => {
+  describe('ClickUp Overrides', () => {
     const dateTestCases = [
       [
         'SUM(DATE(2021,1,1) - 2)',

--- a/test/integration/parsing/formula.js
+++ b/test/integration/parsing/formula.js
@@ -46,6 +46,10 @@ describe('.parse()', () => {
         'CONCATENATE(DATE(2022,1,1) - DATE(2021,1,1))',
         '365',
       ],
+      [
+        'DATE(YEAR(EOMONTH(\'1/1/11\', -3)), MONTH(EOMONTH(\'1/1/11\', -3)), DAY(EOMONTH(\'1/1/11\', -3))) - DATE(2010,10,30)',
+        1,
+      ],
     ];
 
     it.each(dateTestCases)('if the flag "USE_NUMERIC_OVERRIDES" is off, it should not calculate date subtraction', (formula, expectedResult) => {

--- a/test/integration/parsing/formula/financial.js
+++ b/test/integration/parsing/formula/financial.js
@@ -38,7 +38,7 @@ describe('.parse() financial formulas', () => {
     expect(parser.parse('CUMPRINC(0.1/12, 30*12, 100000)')).toMatchObject({error: '#NUM!', result: null});
     expect(parser.parse('CUMPRINC(0.1/12, 30*12, 100000, 13)')).toMatchObject({error: '#NUM!', result: null});
     expect(parser.parse('CUMPRINC(0.1/12, 30*12, 100000, 13, 24)')).toMatchObject({error: '#NUM!', result: null});
-    expect(parser.parse('CUMPRINC(0.1/12, 30*12, 100000, 13, 24, 0)')).toMatchObject({error: null, result: -614.0863271085149});
+    expect(parser.parse('CUMPRINC(0.1/12, 30*12, 100000, 13, 24, 0)')).toMatchObject({error: null, result: -614.0863271085129});
   });
 
   it('DB', () => {
@@ -78,9 +78,9 @@ describe('.parse() financial formulas', () => {
   it('FV', () => {
     expect(parser.parse('FV()')).toMatchObject({error: '#VALUE!', result: null});
     expect(parser.parse('FV(1.1, 10)')).toMatchObject({error: '#VALUE!', result: null});
-    expect(parser.parse('FV(1.1, 10, -200)')).toMatchObject({error: null, result: 303088.7450582});
-    expect(parser.parse('FV(1.1, 10, -200, -500)')).toMatchObject({error: null, result: 1137082.79396825});
-    expect(parser.parse('FV(1.1, 10, -200, -500, 1)')).toMatchObject({error: null, result: 1470480.4135322701});
+    expect(parser.parse('FV(1.1, 10, -200)')).toMatchObject({error: null, result: 303088.74505820015});
+    expect(parser.parse('FV(1.1, 10, -200, -500)')).toMatchObject({error: null, result: 1137082.7939682505});
+    expect(parser.parse('FV(1.1, 10, -200, -500, 1)')).toMatchObject({error: null, result: 1470480.4135322706});
   });
 
   it('FVSCHEDULE', () => {
@@ -94,14 +94,14 @@ describe('.parse() financial formulas', () => {
     expect(parser.parse('IPMT(0.2, 6)')).toMatchObject({error: '#VALUE!', result: null});
     expect(parser.parse('IPMT(0.2, 6, 24)')).toMatchObject({error: '#VALUE!', result: null});
     expect(parser.parse('IPMT(0.2, 6, 24, 1000)')).toMatchObject({error: null, result: -196.20794961065468});
-    expect(parser.parse('IPMT(0.2, 6, 24, 1000, 200)')).toMatchObject({error: null, result: -195.44953953278565});
+    expect(parser.parse('IPMT(0.2, 6, 24, 1000, 200)')).toMatchObject({error: null, result: -195.4495395327856});
     expect(parser.parse('IPMT(0.2, 6, 24, 1000, 200, 1)')).toMatchObject({error: null, result: -162.87461627732137});
   });
 
   it('IRR', () => {
     parser.on('callRangeValue', (a, b, done) => done([[-75000, 12000, 15000, 18000, 21000, 24000]]));
 
-    expect(parser.parse('IRR(A1:C1)')).toMatchObject({error: null, result: 0.05715142887178453});
+    expect(parser.parse('IRR(A1:C1)')).toMatchObject({error: null, result: 0.05715142887178451});
   });
 
   it('ISPMT', () => {

--- a/test/unit/evaluate-by-operator/operator/add.js
+++ b/test/unit/evaluate-by-operator/operator/add.js
@@ -14,4 +14,13 @@ describe('add operator', () => {
     expect(() => func('foo', ' ', 'bar', ' baz')).toThrow('VALUE');
     expect(() => func('foo', 2)).toThrow('VALUE');
   });
+
+  describe('ClickUp Overrides', () => {
+    it.each([
+      'DATE(2021,1,1)',
+      'SUM(DATE(2021,1,1))',
+    ])('Shouldn\'t parse dates or formulas', (formula) => {
+      expect(() => func(formula)).toThrow('VALUE');
+    });
+  });
 });

--- a/test/unit/evaluate-by-operator/operator/minus.js
+++ b/test/unit/evaluate-by-operator/operator/minus.js
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-named-as-default-member */
 import func from '../../../../src/evaluate-by-operator/operator/minus';
+import ClickUpConfiguration from '../../../../src/clickup.config';
 
 describe('minus operator', () => {
   it('should set SYMBOL const', () => {
@@ -15,8 +16,19 @@ describe('minus operator', () => {
     expect(() => func('foo', 2)).toThrow('VALUE');
   });
 
-  // DATE(YEAR, MONTH, DAY)
-  describe.only('Dates subtraction', () => {
+  describe('Dates subtraction', () => {
+    beforeAll(() => {
+      Object.assign(ClickUpConfiguration, {
+        UseNumericOverrides: true,
+      });
+    });
+
+    afterAll(() => {
+      Object.assign(ClickUpConfiguration, {
+        UseNumericOverrides: false,
+      });
+    });
+
     const testCases = [
       // simple formulas
       [0, 'DATE(2023,1,1)', 'DATE(2023,1,1)'],

--- a/test/unit/evaluate-by-operator/operator/minus.js
+++ b/test/unit/evaluate-by-operator/operator/minus.js
@@ -19,13 +19,15 @@ describe('minus operator', () => {
   describe('Dates subtraction', () => {
     beforeAll(() => {
       Object.assign(ClickUpConfiguration, {
-        UseNumericOverrides: true,
+        ConvertDatesToNumbers: true,
+        ConvertFormulasInNumbers: true,
       });
     });
 
     afterAll(() => {
       Object.assign(ClickUpConfiguration, {
-        UseNumericOverrides: false,
+        ConvertDatesToNumbers: false,
+        ConvertFormulasInNumbers: false,
       });
     });
 

--- a/test/unit/evaluate-by-operator/operator/minus.js
+++ b/test/unit/evaluate-by-operator/operator/minus.js
@@ -14,4 +14,26 @@ describe('minus operator', () => {
     expect(() => func('foo', ' ', 'bar', ' baz')).toThrow('VALUE');
     expect(() => func('foo', 2)).toThrow('VALUE');
   });
+
+  // DATE(YEAR, MONTH, DAY)
+  describe.only('Dates subtraction', () => {
+    const testCases = [
+      // simple formulas
+      [0, 'DATE(2023,1,1)', 'DATE(2023,1,1)'],
+      [0, 'DATE(2024,1,1)', 'DATE(2024,1,1)'],
+      [-1, 'DATE(2024,1,1)', 'DATE(2024,1,2)'],
+      [1, 'DATE(2024,1,2)', 'DATE(2024,1,1)'],
+      [31, 'DATE(2024,2,1)', 'DATE(2024,1,1)'],
+      [-31, 'DATE(2024,1,1)', 'DATE(2024,2,1)'],
+      [-365, 'DATE(2022,1,1)', 'DATE(2023,1,1)'],
+      [365, 'DATE(2023,1,1)', 'DATE(2022,1,1)'],
+      // leap years
+      [-366, 'DATE(2024,1,1)', 'DATE(2025,1,1)'],
+      [366, 'DATE(2025,1,1)', 'DATE(2024,1,1)'],
+    ];
+
+    it.each(testCases)('Should correctly subtract dates. Should return %s', (expectedValue, first, second) => {
+      expect(func(first, second)).toBe(expectedValue);
+    });
+  });
 });

--- a/test/unit/helper/formula.js
+++ b/test/unit/helper/formula.js
@@ -1,0 +1,20 @@
+import splitFormula from '../../../src/helper/formula';
+
+describe('Formula unit tests', () => {
+  const testCases = [
+    ['DATE(2022, 4, 1)', 'DATE', [2022, 4, 1]],
+    ['DAY(2024, 1, 1)', 'DAY', [2024, 1, 1]],
+    ['COMPLEX.FORMULA(1,2,"abc")', 'COMPLEX.FORMULA', [1, 2, 'abc']],
+    ['TODAY()', 'TODAY', []],
+  ];
+
+  it.each(testCases)('Should split the formula. Formula: %s', (formula, expectedName, expectedArgs) => {
+    const {
+      name,
+      args,
+    } = splitFormula(formula);
+
+    expect(name).toBe(expectedName);
+    expect(args).toStrictEqual(expectedArgs);
+  });
+});


### PR DESCRIPTION
## Description

Adding the ability to subtract dates from each other in simple and advanced formula builders. From now, users are able to subtract dates from each other.

Available combinations include:
- Custom formula methods (`TODAY()`)
- Custom formula variables (task and field variables)
- Custom formula dates (`DATE(YYYY,MM,DD)`, `EOMONTH(YYYY, MM)`, etc.)

## How To Use

In your parser implementation, set a variable `CONVERT_DATES_TO_NUMBERS` and `CONVERT_FORMULAS_IN_NUMBERS` to `true`.

example:
```
parser.setVariable("CONVERT_FORMULAS_IN_NUMBERS", true);
parser.setVariable("CONVERT_DATES_TO_NUMBERS", true);
```

this would enable dates support in numeric values