### PR TITLE
feat: use formula ADD when using + operator

### DIFF
--- a/src/evaluate-by-operator/operator/add.js
+++ b/src/evaluate-by-operator/operator/add.js
@@ -1,10 +1,10 @@
-import { ADD } from '@formulajs/formulajs';
 import { ERROR_VALUE } from './../../error';
+import { toNumber } from '../../helper/number';
 
 export const SYMBOL = '+';
 
 export default function func(first, ...rest) {
-    const result = rest.reduce((acc, value) => ADD(acc, value), first);
+    const result = rest.reduce((acc, value) => acc + toNumber(value), toNumber(first));
 
     if (isNaN(result)) {
         throw Error(ERROR_VALUE);

--- a/src/evaluate-by-operator/operator/add.js
+++ b/src/evaluate-by-operator/operator/add.js
@@ -1,5 +1,5 @@
-import { ERROR_VALUE } from './../../error';
 import { toNumber } from '../../helper/number';
+import { ERROR_VALUE } from './../../error';
 
 export const SYMBOL = '+';
 

--- a/src/evaluate-by-operator/operator/add.js
+++ b/src/evaluate-by-operator/operator/add.js
@@ -1,10 +1,10 @@
-import { toNumber } from './../../helper/number';
+import { ADD } from '@formulajs/formulajs';
 import { ERROR_VALUE } from './../../error';
 
 export const SYMBOL = '+';
 
 export default function func(first, ...rest) {
-    const result = rest.reduce((acc, value) => acc + toNumber(value), toNumber(first));
+    const result = rest.reduce((acc, value) => ADD(acc, value), first);
 
     if (isNaN(result)) {
         throw Error(ERROR_VALUE);

--- a/src/helper/number.js
+++ b/src/helper/number.js
@@ -18,8 +18,8 @@ export function toNumber(
         convertFormulasInNumbers: false,
     }
 ) {
-    if (value === null || value === undefined) {
-        return 0;
+    if (value === null || value === undefined || isNaN(value)) {
+        return undefined;
     }
 
     if (typeof value === 'number') {

--- a/src/helper/number.js
+++ b/src/helper/number.js
@@ -18,7 +18,7 @@ export function toNumber(
         convertFormulasInNumbers: false,
     }
 ) {
-    if (value === null || value === undefined || isNaN(value)) {
+    if (value === null || value === undefined || value === '') {
         return undefined;
     }
 
@@ -30,7 +30,8 @@ export function toNumber(
         const shouldBeParsed = AcceptedFormulaJSConversions.some((conversion) => value.startsWith(conversion));
         if (shouldBeParsed && Boolean(config.convertFormulasInNumbers)) {
             const { name, args } = splitFormula(value);
-            return toNumber(formulajs[name](...args), config);
+            const formulaResult = formulajs[name](...args);
+            return toNumber(formulaResult, config);
         }
 
         return value.indexOf('.') > -1 ? parseFloat(value) : parseInt(value, 10);

--- a/test/unit/evaluate-by-operator/operator/add.js
+++ b/test/unit/evaluate-by-operator/operator/add.js
@@ -13,6 +13,8 @@ describe('add operator', () => {
         expect(func('2', '-8.8', 6, 0.4)).toBe(-0.4000000000000007);
         expect(() => func('foo', ' ', 'bar', ' baz')).toThrow('VALUE');
         expect(() => func('foo', 2)).toThrow('VALUE');
+        expect(() => func(2, null)).toThrow('VALUE');
+        expect(() => func(null, 2)).toThrow('VALUE');
     });
 
     describe('ClickUp Overrides', () => {

--- a/test/unit/evaluate-by-operator/operator/add.js
+++ b/test/unit/evaluate-by-operator/operator/add.js
@@ -14,7 +14,11 @@ describe('add operator', () => {
         expect(() => func('foo', ' ', 'bar', ' baz')).toThrow('VALUE');
         expect(() => func('foo', 2)).toThrow('VALUE');
         expect(() => func(2, null)).toThrow('VALUE');
+        expect(() => func(2, undefined)).toThrow('VALUE');
+        expect(() => func(2, '')).toThrow('VALUE');
         expect(() => func(null, 2)).toThrow('VALUE');
+        expect(() => func(undefined, 2)).toThrow('VALUE');
+        expect(() => func('', 2)).toThrow('VALUE');
     });
 
     describe('ClickUp Overrides', () => {

--- a/test/unit/evaluate-by-operator/operator/divide.js
+++ b/test/unit/evaluate-by-operator/operator/divide.js
@@ -10,8 +10,14 @@ describe('divide operator', () => {
         expect(func(2, 8.8)).toBe(0.22727272727272727);
         expect(func('2', 8.8)).toBe(0.22727272727272727);
         expect(func('2', '-8.8', 6, 0.4)).toBe(-0.0946969696969697);
-        expect(() => func('foo', ' ', 'bar', ' baz')).toThrow('VALUE');
         expect(func(0, 1)).toBe(0);
         expect(() => func(1, 0)).toThrow('DIV/0');
+        expect(() => func('foo', ' ', 'bar', ' baz')).toThrow('VALUE');
+        expect(() => func(null, 2)).toThrow('VALUE');
+        expect(() => func(undefined, 2)).toThrow('VALUE');
+        expect(() => func('', 2)).toThrow('VALUE');
+        expect(() => func(2, null)).toThrow('VALUE');
+        expect(() => func(2, undefined)).toThrow('VALUE');
+        expect(() => func(2, '')).toThrow('VALUE');
     });
 });

--- a/test/unit/evaluate-by-operator/operator/multiply.js
+++ b/test/unit/evaluate-by-operator/operator/multiply.js
@@ -13,5 +13,11 @@ describe('multiply operator', () => {
         expect(func('2', '-8.8', 6, 0.4)).toBe(-42.24000000000001);
         expect(() => func('foo', ' ', 'bar', ' baz')).toThrow('VALUE');
         expect(() => func('foo', 2)).toThrow('VALUE');
+        expect(() => func(2, null)).toThrow('VALUE');
+        expect(() => func(2, undefined)).toThrow('VALUE');
+        expect(() => func(2, '')).toThrow('VALUE');
+        expect(() => func(null, 2)).toThrow('VALUE');
+        expect(() => func(undefined, 2)).toThrow('VALUE');
+        expect(() => func('', 2)).toThrow('VALUE');
     });
 });

--- a/test/unit/evaluate-by-operator/operator/power.js
+++ b/test/unit/evaluate-by-operator/operator/power.js
@@ -13,5 +13,11 @@ describe('power operator', () => {
         expect(func('2', '8.8', 6, 0.4)).toBe(445.7218884076158);
         expect(() => func('foo', ' ', 'bar', ' baz')).toThrow('VALUE');
         expect(() => func('foo', 2)).toThrow('VALUE');
+        expect(() => func(2, null)).toThrow('VALUE');
+        expect(() => func(2, undefined)).toThrow('VALUE');
+        expect(() => func(2, '')).toThrow('VALUE');
+        expect(() => func(null, 2)).toThrow('VALUE');
+        expect(() => func(undefined, 2)).toThrow('VALUE');
+        expect(() => func('', 2)).toThrow('VALUE');
     });
 });

--- a/test/unit/helper/number.js
+++ b/test/unit/helper/number.js
@@ -12,8 +12,8 @@ describe('.toNumber()', () => {
         expect(toNumber('-10')).toBe(-10);
         expect(toNumber(' -10 ')).toBe(-10);
         expect(isNaN(toNumber('foo'))).toBe(true);
-        expect(toNumber(null)).toBe(0);
-        expect(toNumber(undefined)).toBe(0);
+        expect(toNumber(null)).toBe(undefined);
+        expect(toNumber(undefined)).toBe(undefined);
     });
 });
 


### PR DESCRIPTION
# Summary

Updated the `toNumber` function to match what to a similar function in `@formulajs` package. This ensures the arguments are treated equally between e.g. `+` operator and `add()` function/formula.

# Testing

- added a bunch of tests for operators with expected behaviour