### PR TITLE
chore(fields): export ParseResult interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@time-loop/hot-formula-parser",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "description": "Formula parser",
     "type": "commonjs",
     "main": "dist/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import Parser from './parser';
 import { ClickUpParser } from './clickup/clickupParser';
+import { ParseResult } from './parse-result';
 import SUPPORTED_FORMULAS from './supported-formulas';
 import error, {
     ERROR,
@@ -36,6 +37,7 @@ export {
     ERROR_LEVEL,
     Parser,
     ClickUpParser,
+    ParseResult,
     error,
     extractLabel,
     toLabel,


### PR DESCRIPTION
# Summary

`ParseResult` interface is a useful type for strong-typing the parsing results; the users of the lib might want to use directly instead of importing from `/dist`.