### PR TITLE
fix(fields): correctly calculate nesting level in ClickUpFieldsDependencyTracker [CLK-520023]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@time-loop/hot-formula-parser",
-    "version": "4.0.2",
+    "version": "4.0.3",
     "description": "Formula parser",
     "type": "commonjs",
     "main": "dist/index.js",

--- a/test/unit/clickup/clickupFieldsDependencyTracker.test.ts
+++ b/test/unit/clickup/clickupFieldsDependencyTracker.test.ts
@@ -45,14 +45,24 @@ describe('clickupFieldsValidator', () => {
     it('should detect nesting is too deep', () => {
         const variables = [
             createClickUpParserVariable(CF_1_NAME, 10),
-            createClickUpParserVariable(CF_2_NAME, 20),
-            createClickUpParserVariable(CF_3_NAME, `${CF_1_NAME} + ${CF_2_NAME}`, true),
+            createClickUpParserVariable(CF_2_NAME, `${CF_1_NAME} * ${CF_1_NAME}`, true),
+            createClickUpParserVariable(CF_3_NAME, `${CF_2_NAME} * ${CF_2_NAME}`, true),
             createClickUpParserVariable(CF_4_NAME, `${CF_2_NAME} + ${CF_3_NAME}`, true),
-            createClickUpParserVariable(CF_5_NAME, `${CF_3_NAME} + ${CF_4_NAME}`, true),
         ];
-        const validator = new ClickUpFieldsDependencyTracker(variables, 2);
+        const validator = new ClickUpFieldsDependencyTracker(variables, 1);
 
         expect(() => validator.validate()).toThrow('Nesting is too deep');
+    });
+
+    it('should pass if nesting equal to max level', () => {
+        const variables = [
+            createClickUpParserVariable(CF_1_NAME, 4),
+            createClickUpParserVariable(CF_2_NAME, `${CF_1_NAME} * ${CF_1_NAME}`, true),
+            createClickUpParserVariable(CF_3_NAME, `3 * ${CF_2_NAME}`, true),
+        ];
+        const validator = new ClickUpFieldsDependencyTracker(variables, 1);
+
+        expect(() => validator.validate()).not.toThrow();
     });
 
     describe('performance tests', () => {

--- a/test/unit/clickup/clickupFieldsDependencyTracker.test.ts
+++ b/test/unit/clickup/clickupFieldsDependencyTracker.test.ts
@@ -54,7 +54,7 @@ describe('clickupFieldsValidator', () => {
         expect(() => validator.validate()).toThrow('Nesting is too deep');
     });
 
-    it('should pass if nesting equal to max level', () => {
+    it('should pass if nesting is equal to max level', () => {
         const variables = [
             createClickUpParserVariable(CF_1_NAME, 4),
             createClickUpParserVariable(CF_2_NAME, `${CF_1_NAME} * ${CF_1_NAME}`, true),


### PR DESCRIPTION
# Summary

When calculating the depth of a given formula, we need not to take into account the non-formula dependencies to have the "nesting level" definition conform to the one accepted, i.e. we count only formulas.

# Tests

- updated tests
- tests ✅ 