### PR TITLE
feat: change the validation method [CLK-520359]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@time-loop/hot-formula-parser",
-    "version": "4.0.3",
+    "version": "4.1.0",
     "description": "Formula parser",
     "type": "commonjs",
     "main": "dist/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ import {
     rowLabelToIndex,
     toLabel,
 } from './helper/cell';
-import { ClickUpFieldsDependencyTracker } from './clickup/clickupFieldsDependencyTracker';
+import { ClickUpFieldsDependencyTracker, ValidationResult } from './clickup/clickupFieldsDependencyTracker';
 
 export {
     SUPPORTED_FORMULAS,
@@ -40,6 +40,7 @@ export {
     ClickUpParser,
     ParseResult,
     ClickUpFieldsDependencyTracker,
+    ValidationResult,
     error,
     extractLabel,
     toLabel,


### PR DESCRIPTION
# Summary

Updating the `ClickUpFieldsDependencyTracker` class:

- constructor no longer accepts `maxLevels` parameter, as it is not used now
- the `validate()` method does not throw; instead it returns `ValidationResult` containing information whether the variables graph has cycles, what variables cause circular dependencies, and what is the nesting level of each variable (formula not referencing formulas is 0, formula referencing plain formula is 1, etc.)
- added method to get a variable dependencies (which variables a function depends on) - can be used for access checks

# Testing

- updated unit tests
- tests ✅ 