### PR TITLE
ci(publishing): add publishing in CI based on releases [CLK-481423]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+    push:
+        branches: [develop]
     pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-    push:
-        branches: [develop]
     pull_request:
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+# Simple GitHub Packages publishing based on:
+# https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-nodejs-packages#example-workflow
+name: Publish
+
+on:
+    release:
+        types: [published]
+
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version-file: .nvmrc
+                  cache: 'npm'
+                  registry-url: 'https://npm.pkg.github.com'
+            - run: npm ci
+            - run: npm publish
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.WRITE_PACKAGES_PAT }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,12 @@ jobs:
                   cache: 'npm'
                   registry-url: 'https://npm.pkg.github.com'
             - run: npm ci
+            - name: Generate token
+              id: generate-token
+              uses: actions/create-github-app-token@31c86eb3b33c9b601a1f60f98dcbfd1d70f379b4 # v1.10.3
+              with:
+                  app-id: ${{ vars.CLICKUP_GITHUB_BOT_APP_ID }}
+                  private-key: ${{ secrets.CLICKUP_GITHUB_BOT_PRIVATE_KEY }}
             - run: npm publish
               env:
-                  NODE_AUTH_TOKEN: ${{ secrets.WRITE_PACKAGES_PAT }}
+                  NODE_AUTH_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ $ npm install --save @time-loop/hot-formula-parser
 
 Simple usage:
 ```js
-import { Parser } from '@time-loop/hot-formula-parser';
+import { ClickUpParser } from '@time-loop/hot-formula-parser';
 
-const parser = new Parser();
+const parser = ClickUpParser.create();
 
 parser.parse('SUM(1, 6, 7)'); // It returns `Object {error: null, result: 14}`
 ```
@@ -41,9 +41,9 @@ It supports:
 ## API (methods)
 
 ```js
-import { Parser } from '@time-loop/hot-formula-parser';
+import { ClickUpParser } from '@time-loop/hot-formula-parser';
 
-const parser = new Parser();
+const parser = ClickUpParser.create();
 ```
 
 ### .parse(expression)
@@ -214,19 +214,3 @@ parser.parse('ROWS(A1:E2)'); // returns `2`
 parser.parse('COUNT(A1:E2)'); // returns `10`
 parser.parse('COUNTIF(A1:E2, ">5")'); // returns `5`
 ```
-
-### Want to help?
-
-Please see [CONTRIBUTING.md](CONTRIBUTING.md).
-
-### Changelog
-
-To see the list of recent changes, see [Releases section](https://github.com/handsontable/formula-parser/releases).
-
-### License
-
-The MIT License (see the [LICENSE](https://github.com/handsontable/formula-parser/blob/master/LICENSE) file for the full text).
-
-### Contact
-
-You can contact us at hello@handsontable.com.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/time-loop/formula-parser.git"
+        "url": "git+https://github.com/time-loop/github-packages.git"
     },
     "publishConfig": {
         "registry": "https://npm.pkg.github.com/"


### PR DESCRIPTION
[GitHub docs](https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-nodejs-packages) suggest a simple workflow of publishing new packages based on new releases - this way we should be able to make any necessary changes, merge them to the trunk and then release whenever we're ready by generating a new release in the UI.

💡  Our `npm publish` command already runs tests and lints the source code before building.