### PR TITLE
feat(fields): trim string variables before use [CLK-547306]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@time-loop/hot-formula-parser",
-    "version": "4.1.0",
+    "version": "4.1.1",
     "description": "Formula parser",
     "type": "commonjs",
     "main": "dist/index.js",

--- a/src/parser.js
+++ b/src/parser.js
@@ -93,8 +93,10 @@ export default class Parser {
      * @returns {Parser}
      */
     setVariable(name, value) {
+        if (typeof value === 'string') {
+            value = value.trim();
+        }
         this.variables[name] = value;
-
         return this;
     }
 

--- a/test/unit/parser.js
+++ b/test/unit/parser.js
@@ -367,4 +367,22 @@ describe('Parser', () => {
             expect(() => parser._throwError('VALUE foo')).toThrow('ERROR');
         });
     });
+
+    describe('handling variables', () => {
+        it('should trim string variable values', () => {
+            parser.setVariable('CF_FOO', '  bar  ');
+            expect(parser.getVariable('CF_FOO')).toBe('bar');
+        });
+
+        it.each(['   bar   ', '  \tbar\n   ', '\n\n\nbar\n\n\n'])(
+            'IF formula with string variable should trim variable value',
+            (value) => {
+                parser.setVariable('CF_FOO', value);
+                expect(parser.parse('IF(EXACT(CF_FOO, "bar"), "yes", "no")')).toMatchObject({
+                    error: null,
+                    result: 'yes',
+                });
+            }
+        );
+    });
 });


### PR DESCRIPTION
# Summary

As string variables can be used in comparisons, we must ensure that whitespace before or after the variable value does not distort the comparison result.
For example, `long_text` custom field always adds `\n` character at the end of the string, which causes issues when comparing the variable with some known string.

# Testing

- all existing tests ✅ 
- added specific test for this fix