### PR TITLE
fix(fields): fix publish CI action [CLK-547306]

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,7 @@ jobs:
               id: generate-token
               uses: actions/create-github-app-token@31c86eb3b33c9b601a1f60f98dcbfd1d70f379b4 # v1.10.3
               with:
+                  repositories: github-packages
                   app-id: ${{ vars.CLICKUP_GITHUB_BOT_APP_ID }}
                   private-key: ${{ secrets.CLICKUP_GITHUB_BOT_PRIVATE_KEY }}
             - run: npm publish


### PR DESCRIPTION
# Summary

Currently packages publishing is done under the repo `github-packages`, so in order to generate a correct access token for publishing, we need to pass this repo name to the action.

This should fix the publishing action.