### PR TITLE
fix(fields): use static token for publishing the package [CLK-547306]

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,13 +17,6 @@ jobs:
                   cache: 'npm'
                   registry-url: 'https://npm.pkg.github.com'
             - run: npm ci
-            - name: Generate token
-              id: generate-token
-              uses: actions/create-github-app-token@31c86eb3b33c9b601a1f60f98dcbfd1d70f379b4 # v1.10.3
-              with:
-                  repositories: github-packages
-                  app-id: ${{ vars.CLICKUP_GITHUB_BOT_APP_ID }}
-                  private-key: ${{ secrets.CLICKUP_GITHUB_BOT_PRIVATE_KEY }}
             - run: npm publish
               env:
-                  NODE_AUTH_TOKEN: ${{ steps.generate-token.outputs.token }}
+                  NODE_AUTH_TOKEN: ${{ secrets.PROJEN_GITHUB_TOKEN }}


### PR DESCRIPTION
# Summary

It seems that we cannot publish packages with a GitHub app token.
Trying to use `PROJEN_GITHUB_TOKEN` as a static auth token for publishing packages.
