### PR TITLE
feat(fields): do not pass NaN in FinF [CLK-656138]

### DIFF
--- a/src/clickup/clickupParser.ts
+++ b/src/clickup/clickupParser.ts
@@ -66,6 +66,13 @@ export class ClickUpParser {
         if (error) {
             throw new Error(error);
         }
+
+        if (Number.isNaN(result)) {
+            // this formula could not be calculated, but is used as a variable
+            // for another formula. Formulas do not accept NaN, so we need to
+            // map this to null
+            return null;
+        }
         return result;
     }
 

--- a/test/unit/clickup/clickupParser.test.ts
+++ b/test/unit/clickup/clickupParser.test.ts
@@ -29,6 +29,22 @@ describe('ClickUpParser', () => {
         expect(result).toEqual({ error: null, result: 110 });
     });
 
+    it('should handle empty variables in internal formulas', () => {
+        const parser = ClickUpParser.create();
+        // empty variable
+        parser.setVariable(CF_1, null);
+        // formula using empty variable
+        // this formula would normally return NaN, but called from a formula
+        // we need to return null or we get #VALUE! error
+        parser.setVariable(CF_2, `${CF_1} * 2`, true);
+        // set variable
+        parser.setVariable(CF_3, 50);
+        // formula using set variable and a formula using empty variable
+        const formula = `${CF_3} - ${CF_2}`;
+        const result = parser.parse(formula);
+        expect(result).toEqual({ error: null, result: Number.NaN });
+    });
+
     it('should return error if formula variable is invalid', () => {
         const parser = ClickUpParser.create();
         parser.setVariable(CF_1, '100/0', true);


### PR DESCRIPTION
## Summary

If a formula is a variable to another formula, we can't use NaN to indicate the impossibility to calculate it (for example because of a missing variable value). In such cases, we must provide null to indicate missing value as with normal variables.

Fix added and a test case for it.

## PRs in the Stack
- ➡ #33

(The stack is managed by [git-grok](https://github.com/dimikot/git-grok).)
